### PR TITLE
rust imports moved in new version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 use core::{
     num::ParseIntError,
     ops::{BitAnd, Deref},
-    simd::{Mask, Simd, SimdPartialEq, ToBitMask},
+    simd::{Mask, Simd, cmp::SimdPartialEq},
     str::FromStr,
 };
 


### PR DESCRIPTION
Rust moved the import for `simd::SimdPartialEq`